### PR TITLE
Indicate errors in the exit code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -520,11 +520,8 @@ int main(int argc, char **argv) {
     CLI11_PARSE(app, argc, argv);
 
     if (server_subcommand->parsed()) {
-        StartServer(server_config);
+        return -StartServer(server_config);
     } else if (client_subcommand->parsed()) {
-        StartClient(client_config);
+        return -StartClient(client_config);
     }
-
-
-    return 0;
 }


### PR DESCRIPTION
Previously, the program always exited with 0, even on failure. Both StartServer() and StartClient() return negative values in that case, so just negate them and use as exit code.