### PR TITLE
Increase stats reporting interval

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -367,7 +367,7 @@ int StartServer(const ServerConfig &config) {
                              raw_bytes_read, udp_packets_read, udp_bytes_read);
                 raw_packets_read = raw_bytes_read = udp_packets_read = udp_bytes_read = 0;
                 state_mutex.unlock();
-                sleep(1);
+                sleep(10);
             }
         }
     };
@@ -483,7 +483,7 @@ int StartClient(const ClientConfig &config) {
                              raw_bytes_read, udp_packets_read, udp_bytes_read);
                 raw_packets_read = raw_bytes_read = udp_packets_read = udp_bytes_read = 0;
                 state_mutex.unlock();
-                sleep(1);
+                sleep(10);
             }
         }
     };


### PR DESCRIPTION
One line per second is a lot if etherbridge is run as a service. Even ten seconds, but that's still 10x less.